### PR TITLE
Removed warnings for implicit type conversions

### DIFF
--- a/parse.cc
+++ b/parse.cc
@@ -222,12 +222,12 @@ vector<Edge> Parser::get_edges() const
     return ret;
 }
 
-int Parser::get_osm_nodes() const
+unsigned long Parser::get_osm_nodes() const
 {
     return nodes.size();
 }
 
-int Parser::get_osm_ways() const
+unsigned long long Parser::get_osm_ways() const
 {
     return ways_count;
 }

--- a/parse.h
+++ b/parse.h
@@ -66,9 +66,9 @@ struct Node
 
 struct Edge
 { 
-    int edge_id;
-    int source;
-    int target;
+    unsigned long long edge_id;
+    unsigned long long source;
+    unsigned long long target;
     float length;
     char car;
     char car_d;
@@ -106,7 +106,7 @@ struct Parser
     void read(char *, int, bool);
     std::vector<Node> get_nodes() const;
     std::vector<Edge> get_edges() const;
-    int get_osm_nodes() const;
-    int get_osm_ways() const;
+    unsigned long get_osm_nodes() const;
+    unsigned long long get_osm_ways() const;
 
 };

--- a/parse.i
+++ b/parse.i
@@ -35,9 +35,9 @@ class Edge_property
 
 struct Edge
 { 
-    unsigned long edge_id;
-    unsigned long source;
-    unsigned long target;
+    unsigned long long edge_id;
+    unsigned long long source;
+    unsigned long long target;
     float length;
     char car;
     char car_d;


### PR DESCRIPTION
I have made a few changes on variable types and return types for removing compilation warnings about implicit type conversions that can possibly lead to numerical errors.  
